### PR TITLE
feat: add configurable timeout for API requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ You can get a token for free by [creating a Crawlbase account](https://crawlbase
 api = Crawlbase::API.new(token: 'YOUR_TOKEN')
 ```
 
+By default, the timeout for API requests is set to 90 seconds. You can configure a custom timeout by passing a `timeout` option during initialization.
+
+```ruby
+api = Crawlbase::API.new(token: 'YOUR_TOKEN', timeout: 120)
+```
+
 ### GET requests
 
 Pass the url that you want to scrape plus any options from the ones available in the [API documentation](https://crawlbase.com/dashboard/docs).
@@ -357,7 +363,7 @@ The gem is available as open source under the terms of the [MIT License](http://
 
 ## Code of Conduct
 
-Everyone interacting in the Crawlbase project’s codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/crawlbase-source/crawlbase-ruby/blob/master/CODE_OF_CONDUCT.md).
+Everyone interacting in the Crawlbase project's codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/crawlbase-source/crawlbase-ruby/blob/master/CODE_OF_CONDUCT.md).
 
 ---
 

--- a/crawlbase.gemspec
+++ b/crawlbase.gemspec
@@ -24,6 +24,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "rexml"
+
   spec.add_development_dependency "rspec", "~> 3.2"
   spec.add_development_dependency "webmock", "~> 3.4"
   spec.add_development_dependency "bundler", "~> 2.0"

--- a/crawlbase.gemspec
+++ b/crawlbase.gemspec
@@ -24,10 +24,9 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rexml"
-
   spec.add_development_dependency "rspec", "~> 3.2"
   spec.add_development_dependency "webmock", "~> 3.4"
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 12.3.3"
+  spec.add_development_dependency "rexml", "~> 3.2"
 end

--- a/lib/crawlbase/api.rb
+++ b/lib/crawlbase/api.rb
@@ -6,23 +6,26 @@ require 'uri'
 
 module Crawlbase
   class API
-    attr_reader :token, :body, :status_code, :original_status, :pc_status, :url, :storage_url
+    attr_reader :token, :body, :status_code, :original_status, :pc_status, :url, :storage_url, :timeout
 
     INVALID_TOKEN = 'Token is required'
     INVALID_URL = 'URL is required'
+    DEFAULT_TIMEOUT = 90
 
     def initialize(options = {})
       raise INVALID_TOKEN if options[:token].nil?
 
       @token = options[:token]
+      @timeout = options.fetch(:timeout, DEFAULT_TIMEOUT)
     end
 
     def get(url, options = {})
       raise INVALID_URL if url.empty?
 
       uri = prepare_uri(url, options)
-
-      response = Net::HTTP.get_response(uri)
+      http = build_http(uri)
+      request = Net::HTTP::Get.new(uri.request_uri)
+      response = http.request(request)
 
       prepare_response(response, options[:format])
 
@@ -33,10 +36,7 @@ module Crawlbase
       raise INVALID_URL if url.empty?
 
       uri = prepare_uri(url, options)
-
-      http = Net::HTTP.new(uri.host, uri.port)
-
-      http.use_ssl = true
+      http = build_http(uri)
 
       content_type = options[:post_content_type].to_s.include?('json') ? { 'Content-Type': 'text/json' } : nil
 
@@ -56,6 +56,14 @@ module Crawlbase
     end
 
     private
+
+    def build_http(uri)
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = true
+      http.open_timeout = @timeout
+      http.read_timeout = @timeout
+      http
+    end
 
     def base_url
       'https://api.crawlbase.com'

--- a/lib/crawlbase/version.rb
+++ b/lib/crawlbase/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Crawlbase
-  VERSION = '1.0.0'
+  VERSION = '1.1.0'
 end

--- a/spec/api_spec.rb
+++ b/spec/api_spec.rb
@@ -93,5 +93,4 @@ describe Crawlbase::API do
       expect { api.post('http://httpbin.org/delay/3', {}) }.to raise_error(Net::OpenTimeout)
     end
   end
-
 end

--- a/spec/api_spec.rb
+++ b/spec/api_spec.rb
@@ -10,6 +10,14 @@ describe Crawlbase::API do
     expect(Crawlbase::API.new(token: 'test').token).to eql('test')
   end
 
+  it 'sets default timeout to 90 seconds' do
+    expect(Crawlbase::API.new(token: 'test').timeout).to eql(90)
+  end
+
+  it 'sets a custom timeout' do
+    expect(Crawlbase::API.new(token: 'test', timeout: 120).timeout).to eql(120)
+  end
+
   describe '#get' do
     it 'sends an get request to Crawlbase API' do
       stub_request(:get, 'https://api.crawlbase.com/?token=test&url=http%3A%2F%2Fhttpbin.org%2Fanything%3Fparam1%3Dx%26params2%3Dy').
@@ -27,6 +35,14 @@ describe Crawlbase::API do
       expect(response.pc_status).to eql(200)
       expect(response.url).to eql('http://httpbin.org/anything?param1=x&params2=y')
       expect(response.body).to eql('body')
+    end
+
+    it 'raises a timeout error' do
+      stub_request(:get, 'https://api.crawlbase.com/?token=test_with_timeout&url=http%3A%2F%2Fhttpbin.org%2Fdelay%2F3').to_timeout
+
+      api = Crawlbase::API.new(token: 'test_with_timeout', timeout: 2)
+
+      expect { api.get('http://httpbin.org/delay/3') }.to raise_error(Net::OpenTimeout)
     end
   end
 
@@ -67,6 +83,14 @@ describe Crawlbase::API do
       expect(response.pc_status).to eql(200)
       expect(response.url).to eql('http://httpbin.org/anything?param1=x&params2=y')
       expect(response.body).to eql('body')
+    end
+
+    it 'raises a timeout error' do
+      stub_request(:post, 'https://api.crawlbase.com/?token=test_with_timeout&url=http%3A%2F%2Fhttpbin.org%2Fdelay%2F3').to_timeout
+
+      api = Crawlbase::API.new(token: 'test_with_timeout', timeout: 2)
+
+      expect { api.post('http://httpbin.org/delay/3', {}) }.to raise_error(Net::OpenTimeout)
     end
   end
 


### PR DESCRIPTION
This pull request introduces a configurable timeout for API requests, addressing the issue of calls timing out unexpectedly, as reported in issue #3.

Key changes:
- A `timeout` option has been added to the `Crawlbase::API` initializer, which sets both the open and read timeout for `Net::HTTP`.
- The default timeout is set to 90 seconds, in line with the Crawlbase documentation recommendations.
- The `README.md` has been updated to document the new `timeout` option.
- Tests have been added to verify the timeout functionality.

Example of usage:
```ruby
# Initialize with a custom timeout of 120 seconds
api = Crawlbase::API.new(token: 'YOUR_TOKEN', timeout: 120)
```

Closes #3