### PR TITLE
Deprecate pc_status in favor of cb_status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.2.0] - 2026-07-14
+
+### Added
+
+- `cb_status` reader on `Crawlbase::API` and `Crawlbase::StorageAPI` responses. Parsing prefers `cb_status` from the HTTP/JSON response and falls back to `pc_status` for compatibility with older API responses.
+
+### Deprecated
+
+- `pc_status` is deprecated in favor of `cb_status`. It remains available as an alias and emits a deprecation warning when called. It will be removed in a future major release.

--- a/README.md
+++ b/README.md
@@ -367,4 +367,4 @@ Everyone interacting in the Crawlbase project's codebases, issue trackers, chat 
 
 ---
 
-Copyright 2025 Crawlbase
+Copyright 2026 Crawlbase

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ begin
   response = api.get('https://www.facebook.com/britneyspears')
   puts response.status_code
   puts response.original_status
-  puts response.pc_status
+  puts response.cb_status
   puts response.body
 rescue => exception
   puts exception.backtrace
@@ -133,7 +133,7 @@ You can always get the original status and crawlbase status from the response. R
 response = api.get('https://sfbay.craigslist.org/')
 
 puts response.original_status
-puts response.pc_status
+puts response.cb_status
 ```
 
 ## Scraper API usage
@@ -254,7 +254,7 @@ Pass the [url](https://crawlbase.com/docs/storage-api/parameters/#url) that you 
 begin
   response = storage_api.get('https://www.apple.com')
   puts response.original_status
-  puts response.pc_status
+  puts response.cb_status
   puts response.url
   puts response.status_code
   puts response.rid
@@ -271,7 +271,7 @@ or you can use the [RID](https://crawlbase.com/docs/storage-api/parameters/#rid)
 begin
   response = storage_api.get(RID)
   puts response.original_status
-  puts response.pc_status
+  puts response.cb_status
   puts response.url
   puts response.status_code
   puts response.rid
@@ -304,7 +304,7 @@ To do a bulk request with a list of RIDs, please send the list of rids as an arr
 begin
   response = storage_api.bulk([RID1, RID2, RID3, ...])
   puts response.original_status
-  puts response.pc_status
+  puts response.cb_status
   puts response.url
   puts response.status_code
   puts response.rid

--- a/lib/crawlbase/api.rb
+++ b/lib/crawlbase/api.rb
@@ -6,7 +6,7 @@ require 'uri'
 
 module Crawlbase
   class API
-    attr_reader :token, :body, :status_code, :original_status, :pc_status, :url, :storage_url, :timeout
+    attr_reader :token, :body, :status_code, :original_status, :cb_status, :url, :storage_url, :timeout
 
     INVALID_TOKEN = 'Token is required'
     INVALID_URL = 'URL is required'
@@ -55,6 +55,11 @@ module Crawlbase
       self
     end
 
+    def pc_status
+      warn '[DEPRECATION] Crawlbase::API#pc_status is deprecated and will be removed in a future major release. Use #cb_status instead.', uplevel: 1
+      @cb_status
+    end
+
     private
 
     def build_http(uri)
@@ -80,7 +85,7 @@ module Crawlbase
       res = format == 'json' || base_url.include?('/scraper') ? JSON.parse(response.body) : response
 
       @original_status = res['original_status'].to_i
-      @pc_status = res['pc_status'].to_i
+      @cb_status = (res['cb_status'] || res['pc_status']).to_i
       @url = res['url']
       @storage_url = res['storage_url']
       @status_code = response.code.to_i

--- a/lib/crawlbase/storage_api.rb
+++ b/lib/crawlbase/storage_api.rb
@@ -6,7 +6,7 @@ require 'uri'
 
 module Crawlbase
   class StorageAPI
-    attr_reader :token, :original_status, :pc_status, :url, :status_code, :rid, :body, :stored_at
+    attr_reader :token, :original_status, :cb_status, :url, :status_code, :rid, :body, :stored_at
 
     INVALID_TOKEN = 'Token is required'
     INVALID_RID = 'RID is required'
@@ -30,7 +30,7 @@ module Crawlbase
       res = format == 'json' ? JSON.parse(response.body) : response
 
       @original_status = res['original_status'].to_i
-      @pc_status = res['pc_status'].to_i
+      @cb_status = (res['cb_status'] || res['pc_status']).to_i
       @url = res['url']
       @rid = res['rid']
       @stored_at = res['stored_at']
@@ -50,7 +50,7 @@ module Crawlbase
       request = Net::HTTP::Delete.new(uri.request_uri)
       response = http.request(request)
 
-      @url, @original_status, @pc_status, @stored_at = nil
+      @url, @original_status, @cb_status, @stored_at = nil
       @status_code = response.code.to_i
       @rid = rid
       @body = JSON.parse(response.body)
@@ -71,7 +71,7 @@ module Crawlbase
       @body = JSON.parse(response.body)
       @original_status = @body.map { |item| item['original_status'].to_i }
       @status_code = response.code.to_i
-      @pc_status = @body.map { |item| item['pc_status'].to_i }
+      @cb_status = @body.map { |item| (item['cb_status'] || item['pc_status']).to_i }
       @url = @body.map { |item| item['url'] }
       @rid = @body.map { |item| item['rid'] }
       @stored_at = @body.map { |item| item['stored_at'] }
@@ -86,7 +86,7 @@ module Crawlbase
       uri.query = URI.encode_www_form(query_hash)
 
       response = Net::HTTP.get_response(uri)
-      @url, @original_status, @pc_status, @stored_at = nil
+      @url, @original_status, @cb_status, @stored_at = nil
       @status_code = response.code.to_i
       @body = JSON.parse(response.body)
       @rid = @body
@@ -99,12 +99,17 @@ module Crawlbase
       uri.query = URI.encode_www_form(token: token)
 
       response = Net::HTTP.get_response(uri)
-      @url, @original_status, @pc_status, @stored_at = nil
+      @url, @original_status, @cb_status, @stored_at = nil
       @status_code = response.code.to_i
       @rid = rid
       @body = JSON.parse(response.body)
 
       body['totalCount']
+    end
+
+    def pc_status
+      warn '[DEPRECATION] Crawlbase::StorageAPI#pc_status is deprecated and will be removed in a future major release. Use #cb_status instead.', uplevel: 1
+      @cb_status
     end
 
     private

--- a/lib/crawlbase/version.rb
+++ b/lib/crawlbase/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Crawlbase
-  VERSION = '1.1.0'
+  VERSION = '1.2.0'
 end

--- a/spec/api_spec.rb
+++ b/spec/api_spec.rb
@@ -32,9 +32,35 @@ describe Crawlbase::API do
 
       expect(response.status_code).to eql(200)
       expect(response.original_status).to eql(200)
-      expect(response.pc_status).to eql(200)
+      expect(response.cb_status).to eql(200)
       expect(response.url).to eql('http://httpbin.org/anything?param1=x&params2=y')
       expect(response.body).to eql('body')
+    end
+
+    it 'prefers cb_status over pc_status from the response' do
+      stub_request(:get, 'https://api.crawlbase.com/?token=test&url=http%3A%2F%2Fhttpbin.org%2Fanything').
+        to_return(
+          body: 'body',
+          status: 200,
+          headers: { skip_normalize: true, 'original_status' => 200, 'cb_status' => 201, 'pc_status' => 200, 'url' => 'http://httpbin.org/anything'})
+
+      api = Crawlbase::API.new(token: 'test')
+      response = api.get('http://httpbin.org/anything')
+
+      expect(response.cb_status).to eql(201)
+    end
+
+    it 'keeps pc_status as a deprecated alias of cb_status' do
+      stub_request(:get, 'https://api.crawlbase.com/?token=test&url=http%3A%2F%2Fhttpbin.org%2Fanything').
+        to_return(
+          body: 'body',
+          status: 200,
+          headers: { skip_normalize: true, 'original_status' => 200, 'cb_status' => 200, 'url' => 'http://httpbin.org/anything'})
+
+      api = Crawlbase::API.new(token: 'test')
+      response = api.get('http://httpbin.org/anything')
+
+      expect { expect(response.pc_status).to eql(200) }.to output(/DEPRECATION.*pc_status.*cb_status/).to_stderr
     end
 
     it 'raises a timeout error' do
@@ -61,7 +87,7 @@ describe Crawlbase::API do
 
       expect(response.status_code).to eql(200)
       expect(response.original_status).to eql(200)
-      expect(response.pc_status).to eql(200)
+      expect(response.cb_status).to eql(200)
       expect(response.url).to eql('http://httpbin.org/anything?param1=x&params2=y')
       expect(response.body).to eql('body')
     end
@@ -80,7 +106,7 @@ describe Crawlbase::API do
 
       expect(response.status_code).to eql(200)
       expect(response.original_status).to eql(200)
-      expect(response.pc_status).to eql(200)
+      expect(response.cb_status).to eql(200)
       expect(response.url).to eql('http://httpbin.org/anything?param1=x&params2=y')
       expect(response.body).to eql('body')
     end

--- a/spec/screenshots_api_spec.rb
+++ b/spec/screenshots_api_spec.rb
@@ -26,7 +26,7 @@ describe Crawlbase::ScreenshotsAPI do
 
       expect(response.status_code).to eql(200)
       expect(response.original_status).to eql(200)
-      expect(response.pc_status).to eql(200)
+      expect(response.cb_status).to eql(200)
       expect(response.url).to eql('http://httpbin.org/anything?param1=x&params2=y')
       expect(response.body).to eql('body')
       expect(response.screenshot_path).not_to be_empty
@@ -39,7 +39,7 @@ describe Crawlbase::ScreenshotsAPI do
 
       expect(response.status_code).to eql(200)
       expect(response.original_status).to eql(200)
-      expect(response.pc_status).to eql(200)
+      expect(response.cb_status).to eql(200)
       expect(response.url).to eql('http://httpbin.org/anything?param1=x&params2=y')
       expect(response.body).to eql('body')
       expect(response.screenshot_path).to eql(File.join(Dir.tmpdir, 'test-image.jpg'))
@@ -64,7 +64,7 @@ describe Crawlbase::ScreenshotsAPI do
   
       expect(response.status_code).to eql(200)
       expect(response.original_status).to eql(200)
-      expect(response.pc_status).to eql(200)
+      expect(response.cb_status).to eql(200)
       expect(response.url).to eql('http://httpbin.org/anything?param1=x&params2=y')
       expect(response.body).to eql('body')
       expect(response.screenshot_path).to eql(File.join(Dir.tmpdir, 'test-image.jpg'))

--- a/spec/storage_api_spec.rb
+++ b/spec/storage_api_spec.rb
@@ -11,6 +11,7 @@ describe Crawlbase::StorageAPI do
       stub_request(:get, 'https://api.crawlbase.com/storage?format=html&rid=1&token=test')
         .to_return(
           status: 200,
+          headers: { skip_normalize: true, 'original_status' => 200, 'pc_status' => 200, 'url' => 'https://www.apple.com', 'rid' => '1', 'stored_at' => '2021-03-01T14:22:58+02:00' },
           body: {
             stored_at: '2021-03-01T14:22:58+02:00',
             original_status: 200,
@@ -40,6 +41,12 @@ describe Crawlbase::StorageAPI do
           body: '<html><head><title>Apple</title></head><body>Apple</body></html>'
         }.to_json
       )
+      expect(subject.cb_status).to eq(200)
+    end
+
+    it 'keeps pc_status as a deprecated alias of cb_status' do
+      subject.get('1')
+      expect { expect(subject.pc_status).to eq(200) }.to output(/DEPRECATION.*pc_status.*cb_status/).to_stderr
     end
   end
 
@@ -139,6 +146,7 @@ describe Crawlbase::StorageAPI do
           'https://www.espn.com'
         ]
       )
+      expect(subject.cb_status).to eq([200, 200, 200])
     end
   end
 


### PR DESCRIPTION
## Summary

Deprecates `pc_status` in favor of `cb_status` in a **non-breaking** `1.2.0` release, aligning the Ruby client with Crawlbase naming while keeping existing integrations working.

- Adds `cb_status` on `Crawlbase::API` and `Crawlbase::StorageAPI` (inherited by `ScreenshotsAPI`)
- Keeps `pc_status` as a deprecated alias that returns the same value and emits a deprecation warning
- Preferentially reads `cb_status` from HTTP/JSON responses, with a fallback to `pc_status` so today’s API responses continue to work and future header renames are already supported
- Updates README examples, adds `CHANGELOG.md`, and bumps the version to `1.2.0`

## Migration

```ruby
# Before
response.pc_status

# After
response.cb_status
```

`pc_status` still works in this release and will be removed in a future major version.

## Test plan

- [x] Specs assert `cb_status` as the primary attribute
- [x] Specs cover prefer-`cb_status` / fall-back-to-`pc_status` parsing
- [x] Specs cover deprecated `pc_status` alias + deprecation warning
- [x] `bundle exec rspec` — 26 examples, 0 failures
