### PR TITLE
Deprecate pc_status and introduce preferred cb_status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.2.0] - 2026-07-15
+
+### Added
+
+- `cb_status` as the preferred public attribute for Crawlbase status on `Crawlbase::API` (and subclasses) and `Crawlbase::StorageAPI`.
+- Status resolution prefers the `cb_status` response header or JSON field, then falls back to `pc_status` when `cb_status` is absent.
+
+### Deprecated
+
+- `pc_status` is deprecated but still supported and returns the same resolved value as `cb_status`. A one-time deprecation warning is emitted when `pc_status` is accessed. Prefer `cb_status`. Removal is planned for a future major release.
+
+### Migration
+
+```ruby
+# Before (deprecated)
+response.pc_status
+
+# After (preferred)
+response.cb_status
+```

--- a/README.md
+++ b/README.md
@@ -367,4 +367,4 @@ Everyone interacting in the Crawlbase project's codebases, issue trackers, chat 
 
 ---
 
-Copyright 2025 Crawlbase
+Copyright 2026 Crawlbase

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ begin
   response = api.get('https://www.facebook.com/britneyspears')
   puts response.status_code
   puts response.original_status
-  puts response.pc_status
+  puts response.cb_status
   puts response.body
 rescue => exception
   puts exception.backtrace
@@ -125,16 +125,31 @@ response = api.get('https://www.freelancer.com', options: { page_wait: 5000 })
 puts response.status_code
 ```
 
-## Original status
+## Original status and Crawlbase status
 
-You can always get the original status and crawlbase status from the response. Read the [Crawlbase documentation](https://crawlbase.com/dashboard/docs) to learn more about those status.
+You can always get the original status and Crawlbase status from the response. Read the [Crawlbase documentation](https://crawlbase.com/dashboard/docs) to learn more about those statuses.
+
+Prefer `cb_status` for the Crawlbase status. `pc_status` is deprecated but still supported temporarily and returns the same resolved value.
 
 ```ruby
 response = api.get('https://sfbay.craigslist.org/')
 
 puts response.original_status
-puts response.pc_status
+puts response.cb_status # preferred
+# puts response.pc_status # deprecated; same value as cb_status
 ```
+
+### Migrating from `pc_status` to `cb_status`
+
+```ruby
+# Before (deprecated)
+response.pc_status
+
+# After (preferred)
+response.cb_status
+```
+
+The library reads `cb_status` from the API response first, then falls back to `pc_status` if `cb_status` is not present.
 
 ## Scraper API usage
 
@@ -254,7 +269,7 @@ Pass the [url](https://crawlbase.com/docs/storage-api/parameters/#url) that you 
 begin
   response = storage_api.get('https://www.apple.com')
   puts response.original_status
-  puts response.pc_status
+  puts response.cb_status
   puts response.url
   puts response.status_code
   puts response.rid
@@ -271,7 +286,7 @@ or you can use the [RID](https://crawlbase.com/docs/storage-api/parameters/#rid)
 begin
   response = storage_api.get(RID)
   puts response.original_status
-  puts response.pc_status
+  puts response.cb_status
   puts response.url
   puts response.status_code
   puts response.rid
@@ -304,7 +319,7 @@ To do a bulk request with a list of RIDs, please send the list of rids as an arr
 begin
   response = storage_api.bulk([RID1, RID2, RID3, ...])
   puts response.original_status
-  puts response.pc_status
+  puts response.cb_status
   puts response.url
   puts response.status_code
   puts response.rid

--- a/lib/crawlbase.rb
+++ b/lib/crawlbase.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'crawlbase/version'
+require 'crawlbase/status_resolution'
 require 'crawlbase/api'
 require 'crawlbase/scraper_api'
 require 'crawlbase/leads_api'

--- a/lib/crawlbase/api.rb
+++ b/lib/crawlbase/api.rb
@@ -6,7 +6,11 @@ require 'uri'
 
 module Crawlbase
   class API
-    attr_reader :token, :body, :status_code, :original_status, :pc_status, :url, :storage_url, :timeout
+    # Crawlbase HTTP response code for the API call itself.
+    attr_reader :token, :body, :status_code, :original_status, :url, :storage_url, :timeout
+
+    # Crawlbase status from the response (preferred name for former +pc_status+).
+    attr_reader :cb_status
 
     INVALID_TOKEN = 'Token is required'
     INVALID_URL = 'URL is required'
@@ -17,6 +21,12 @@ module Crawlbase
 
       @token = options[:token]
       @timeout = options.fetch(:timeout, DEFAULT_TIMEOUT)
+    end
+
+    # Deprecated: use {#cb_status}. Returns the same resolved Crawlbase status.
+    def pc_status
+      StatusResolution.warn_pc_status_deprecated
+      @pc_status
     end
 
     def get(url, options = {})
@@ -80,7 +90,8 @@ module Crawlbase
       res = format == 'json' || base_url.include?('/scraper') ? JSON.parse(response.body) : response
 
       @original_status = res['original_status'].to_i
-      @pc_status = res['pc_status'].to_i
+      @cb_status = StatusResolution.resolve_cb_status(res)
+      @pc_status = @cb_status
       @url = res['url']
       @storage_url = res['storage_url']
       @status_code = response.code.to_i

--- a/lib/crawlbase/status_resolution.rb
+++ b/lib/crawlbase/status_resolution.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Crawlbase
+  # Resolves Crawlbase status from response headers or JSON bodies.
+  # Prefers +cb_status+, falling back to deprecated +pc_status+.
+  module StatusResolution
+    PC_STATUS_DEPRECATION =
+      '[Crawlbase] `pc_status` is deprecated and will be removed in a future major release. Use `cb_status` instead.'
+
+    module_function
+
+    def resolve_cb_status(source)
+      raw = source['cb_status']
+      raw = source['pc_status'] if raw.nil? || raw.to_s.empty?
+      raw.to_i
+    end
+
+    def warn_pc_status_deprecated
+      return if Crawlbase.instance_variable_get(:@pc_status_deprecation_warned)
+
+      Crawlbase.instance_variable_set(:@pc_status_deprecation_warned, true)
+      warn PC_STATUS_DEPRECATION, uplevel: 1
+    end
+  end
+end

--- a/lib/crawlbase/storage_api.rb
+++ b/lib/crawlbase/storage_api.rb
@@ -6,7 +6,10 @@ require 'uri'
 
 module Crawlbase
   class StorageAPI
-    attr_reader :token, :original_status, :pc_status, :url, :status_code, :rid, :body, :stored_at
+    attr_reader :token, :original_status, :url, :status_code, :rid, :body, :stored_at
+
+    # Crawlbase status from the response (preferred name for former +pc_status+).
+    attr_reader :cb_status
 
     INVALID_TOKEN = 'Token is required'
     INVALID_RID = 'RID is required'
@@ -20,6 +23,12 @@ module Crawlbase
       @token = options[:token]
     end
 
+    # Deprecated: use {#cb_status}. Returns the same resolved Crawlbase status.
+    def pc_status
+      StatusResolution.warn_pc_status_deprecated
+      @pc_status
+    end
+
     def get(url_or_rid, format = 'html')
       raise INVALID_URL_OR_RID if url_or_rid.nil? || url_or_rid.empty?
 
@@ -30,7 +39,8 @@ module Crawlbase
       res = format == 'json' ? JSON.parse(response.body) : response
 
       @original_status = res['original_status'].to_i
-      @pc_status = res['pc_status'].to_i
+      @cb_status = StatusResolution.resolve_cb_status(res)
+      @pc_status = @cb_status
       @url = res['url']
       @rid = res['rid']
       @stored_at = res['stored_at']
@@ -50,7 +60,7 @@ module Crawlbase
       request = Net::HTTP::Delete.new(uri.request_uri)
       response = http.request(request)
 
-      @url, @original_status, @pc_status, @stored_at = nil
+      @url, @original_status, @cb_status, @pc_status, @stored_at = nil
       @status_code = response.code.to_i
       @rid = rid
       @body = JSON.parse(response.body)
@@ -71,7 +81,8 @@ module Crawlbase
       @body = JSON.parse(response.body)
       @original_status = @body.map { |item| item['original_status'].to_i }
       @status_code = response.code.to_i
-      @pc_status = @body.map { |item| item['pc_status'].to_i }
+      @cb_status = @body.map { |item| StatusResolution.resolve_cb_status(item) }
+      @pc_status = @cb_status
       @url = @body.map { |item| item['url'] }
       @rid = @body.map { |item| item['rid'] }
       @stored_at = @body.map { |item| item['stored_at'] }
@@ -86,7 +97,7 @@ module Crawlbase
       uri.query = URI.encode_www_form(query_hash)
 
       response = Net::HTTP.get_response(uri)
-      @url, @original_status, @pc_status, @stored_at = nil
+      @url, @original_status, @cb_status, @pc_status, @stored_at = nil
       @status_code = response.code.to_i
       @body = JSON.parse(response.body)
       @rid = @body
@@ -99,7 +110,7 @@ module Crawlbase
       uri.query = URI.encode_www_form(token: token)
 
       response = Net::HTTP.get_response(uri)
-      @url, @original_status, @pc_status, @stored_at = nil
+      @url, @original_status, @cb_status, @pc_status, @stored_at = nil
       @status_code = response.code.to_i
       @rid = rid
       @body = JSON.parse(response.body)

--- a/lib/crawlbase/version.rb
+++ b/lib/crawlbase/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Crawlbase
-  VERSION = '1.1.0'
+  VERSION = '1.2.0'
 end

--- a/spec/api_spec.rb
+++ b/spec/api_spec.rb
@@ -2,6 +2,10 @@ require 'spec_helper.rb'
 require 'crawlbase'
 
 describe Crawlbase::API do
+  before(:each) do
+    Crawlbase.instance_variable_set(:@pc_status_deprecation_warned, false)
+  end
+
   it 'raises an error if token is missing' do
     expect { Crawlbase::API.new }.to raise_error(RuntimeError, 'Token is required')
   end
@@ -32,9 +36,98 @@ describe Crawlbase::API do
 
       expect(response.status_code).to eql(200)
       expect(response.original_status).to eql(200)
+      expect(response.cb_status).to eql(200)
       expect(response.pc_status).to eql(200)
       expect(response.url).to eql('http://httpbin.org/anything?param1=x&params2=y')
       expect(response.body).to eql('body')
+    end
+
+    it 'resolves cb_status when only cb_status header is present' do
+      stub_request(:get, 'https://api.crawlbase.com/?token=test&url=http%3A%2F%2Fexample.com').
+        to_return(
+          body: 'body',
+          status: 200,
+          headers: { skip_normalize: true, 'original_status' => 200, 'cb_status' => 201, 'url' => 'http://example.com'})
+
+      response = Crawlbase::API.new(token: 'test').get('http://example.com')
+
+      expect(response.cb_status).to eql(201)
+      expect(response.pc_status).to eql(201)
+    end
+
+    it 'falls back to pc_status when cb_status header is absent' do
+      stub_request(:get, 'https://api.crawlbase.com/?token=test&url=http%3A%2F%2Fexample.com').
+        to_return(
+          body: 'body',
+          status: 200,
+          headers: { skip_normalize: true, 'original_status' => 200, 'pc_status' => 202, 'url' => 'http://example.com'})
+
+      response = Crawlbase::API.new(token: 'test').get('http://example.com')
+
+      expect(response.cb_status).to eql(202)
+      expect(response.pc_status).to eql(202)
+    end
+
+    it 'prefers cb_status when both cb_status and pc_status headers are present' do
+      stub_request(:get, 'https://api.crawlbase.com/?token=test&url=http%3A%2F%2Fexample.com').
+        to_return(
+          body: 'body',
+          status: 200,
+          headers: {
+            skip_normalize: true,
+            'original_status' => 200,
+            'cb_status' => 203,
+            'pc_status' => 500,
+            'url' => 'http://example.com'
+          })
+
+      response = Crawlbase::API.new(token: 'test').get('http://example.com')
+
+      expect(response.cb_status).to eql(203)
+      expect(response.pc_status).to eql(203)
+    end
+
+    it 'returns 0 when neither cb_status nor pc_status header is present' do
+      stub_request(:get, 'https://api.crawlbase.com/?token=test&url=http%3A%2F%2Fexample.com').
+        to_return(
+          body: 'body',
+          status: 200,
+          headers: { skip_normalize: true, 'original_status' => 200, 'url' => 'http://example.com'})
+
+      response = Crawlbase::API.new(token: 'test').get('http://example.com')
+
+      expect(response.cb_status).to eql(0)
+      expect(response.pc_status).to eql(0)
+    end
+
+    it 'resolves cb_status from JSON body keys' do
+      stub_request(:get, 'https://api.crawlbase.com/?format=json&token=test&url=http%3A%2F%2Fexample.com').
+        to_return(
+          body: {
+            'original_status' => 200,
+            'cb_status' => 204,
+            'pc_status' => 500,
+            'url' => 'http://example.com'
+          }.to_json,
+          status: 200)
+
+      response = Crawlbase::API.new(token: 'test').get('http://example.com', format: 'json')
+
+      expect(response.cb_status).to eql(204)
+      expect(response.pc_status).to eql(204)
+    end
+
+    it 'warns once when pc_status is accessed' do
+      stub_request(:get, 'https://api.crawlbase.com/?token=test&url=http%3A%2F%2Fexample.com').
+        to_return(
+          body: 'body',
+          status: 200,
+          headers: { skip_normalize: true, 'pc_status' => 200, 'url' => 'http://example.com'})
+
+      response = Crawlbase::API.new(token: 'test').get('http://example.com')
+
+      expect { response.pc_status }.to output(/`pc_status` is deprecated/).to_stderr
+      expect { response.pc_status }.not_to output(/`pc_status` is deprecated/).to_stderr
     end
 
     it 'raises a timeout error' do
@@ -61,6 +154,7 @@ describe Crawlbase::API do
 
       expect(response.status_code).to eql(200)
       expect(response.original_status).to eql(200)
+      expect(response.cb_status).to eql(200)
       expect(response.pc_status).to eql(200)
       expect(response.url).to eql('http://httpbin.org/anything?param1=x&params2=y')
       expect(response.body).to eql('body')
@@ -80,6 +174,7 @@ describe Crawlbase::API do
 
       expect(response.status_code).to eql(200)
       expect(response.original_status).to eql(200)
+      expect(response.cb_status).to eql(200)
       expect(response.pc_status).to eql(200)
       expect(response.url).to eql('http://httpbin.org/anything?param1=x&params2=y')
       expect(response.body).to eql('body')

--- a/spec/screenshots_api_spec.rb
+++ b/spec/screenshots_api_spec.rb
@@ -2,6 +2,10 @@ require 'spec_helper'
 require 'crawlbase'
 
 describe Crawlbase::ScreenshotsAPI do
+  before(:each) do
+    Crawlbase.instance_variable_set(:@pc_status_deprecation_warned, false)
+  end
+
   it 'raises an error if token is missing' do
     expect { Crawlbase::ScreenshotsAPI.new }.to raise_error(RuntimeError, 'Token is required')
   end
@@ -11,7 +15,7 @@ describe Crawlbase::ScreenshotsAPI do
   end
 
   describe '#get' do
-    before(:each) do 
+    before(:each) do
       stub_request(:get, 'https://api.crawlbase.com/screenshots?token=test&url=http%3A%2F%2Fhttpbin.org%2Fanything%3Fparam1%3Dx%26params2%3Dy').
         to_return(
           body: 'body',
@@ -26,6 +30,7 @@ describe Crawlbase::ScreenshotsAPI do
 
       expect(response.status_code).to eql(200)
       expect(response.original_status).to eql(200)
+      expect(response.cb_status).to eql(200)
       expect(response.pc_status).to eql(200)
       expect(response.url).to eql('http://httpbin.org/anything?param1=x&params2=y')
       expect(response.body).to eql('body')
@@ -39,6 +44,7 @@ describe Crawlbase::ScreenshotsAPI do
 
       expect(response.status_code).to eql(200)
       expect(response.original_status).to eql(200)
+      expect(response.cb_status).to eql(200)
       expect(response.pc_status).to eql(200)
       expect(response.url).to eql('http://httpbin.org/anything?param1=x&params2=y')
       expect(response.body).to eql('body')
@@ -56,14 +62,15 @@ describe Crawlbase::ScreenshotsAPI do
 
     it 'accepts a block' do
       api = Crawlbase::ScreenshotsAPI.new(token: 'test')
-  
+
       response = api.get("http://httpbin.org/anything?param1=x&params2=y", save_to_path: save_to_path) do |file|
         expect(file).to be_kind_of(File)
         expect(file.path).to eql(File.join(Dir.tmpdir, 'test-image.jpg'))
       end
-  
+
       expect(response.status_code).to eql(200)
       expect(response.original_status).to eql(200)
+      expect(response.cb_status).to eql(200)
       expect(response.pc_status).to eql(200)
       expect(response.url).to eql('http://httpbin.org/anything?param1=x&params2=y')
       expect(response.body).to eql('body')

--- a/spec/storage_api_spec.rb
+++ b/spec/storage_api_spec.rb
@@ -2,6 +2,10 @@ require 'spec_helper'
 require 'crawlbase'
 
 describe Crawlbase::StorageAPI do
+  before(:each) do
+    Crawlbase.instance_variable_set(:@pc_status_deprecation_warned, false)
+  end
+
   it 'raises an error if token is missing' do
     expect { Crawlbase::StorageAPI.new }.to raise_error(RuntimeError, 'Token is required')
   end
@@ -40,6 +44,78 @@ describe Crawlbase::StorageAPI do
           body: '<html><head><title>Apple</title></head><body>Apple</body></html>'
         }.to_json
       )
+    end
+
+    it 'resolves cb_status from JSON body with only cb_status' do
+      stub_request(:get, 'https://api.crawlbase.com/storage?format=json&rid=1&token=test')
+        .to_return(
+          status: 200,
+          body: {
+            'stored_at' => '2021-03-01T14:22:58+02:00',
+            'original_status' => 200,
+            'cb_status' => 201,
+            'rid' => '1',
+            'url' => 'https://www.apple.com'
+          }.to_json
+        )
+
+      subject.get('1', 'json')
+      expect(subject.cb_status).to eq(201)
+      expect(subject.pc_status).to eq(201)
+    end
+
+    it 'falls back to pc_status from JSON body when cb_status is absent' do
+      stub_request(:get, 'https://api.crawlbase.com/storage?format=json&rid=1&token=test')
+        .to_return(
+          status: 200,
+          body: {
+            'stored_at' => '2021-03-01T14:22:58+02:00',
+            'original_status' => 200,
+            'pc_status' => 202,
+            'rid' => '1',
+            'url' => 'https://www.apple.com'
+          }.to_json
+        )
+
+      subject.get('1', 'json')
+      expect(subject.cb_status).to eq(202)
+      expect(subject.pc_status).to eq(202)
+    end
+
+    it 'prefers cb_status when both keys are present in JSON body' do
+      stub_request(:get, 'https://api.crawlbase.com/storage?format=json&rid=1&token=test')
+        .to_return(
+          status: 200,
+          body: {
+            'stored_at' => '2021-03-01T14:22:58+02:00',
+            'original_status' => 200,
+            'cb_status' => 203,
+            'pc_status' => 500,
+            'rid' => '1',
+            'url' => 'https://www.apple.com'
+          }.to_json
+        )
+
+      subject.get('1', 'json')
+      expect(subject.cb_status).to eq(203)
+      expect(subject.pc_status).to eq(203)
+    end
+
+    it 'returns 0 when neither cb_status nor pc_status is present' do
+      stub_request(:get, 'https://api.crawlbase.com/storage?format=json&rid=1&token=test')
+        .to_return(
+          status: 200,
+          body: {
+            'stored_at' => '2021-03-01T14:22:58+02:00',
+            'original_status' => 200,
+            'rid' => '1',
+            'url' => 'https://www.apple.com'
+          }.to_json
+        )
+
+      subject.get('1', 'json')
+      expect(subject.cb_status).to eq(0)
+      expect(subject.pc_status).to eq(0)
     end
   end
 
@@ -139,6 +215,44 @@ describe Crawlbase::StorageAPI do
           'https://www.espn.com'
         ]
       )
+      expect(subject.cb_status).to eq([200, 200, 200])
+      expect(subject.pc_status).to eq([200, 200, 200])
+    end
+
+    it 'resolves per-item cb_status with preference over pc_status' do
+      stub_request(:post, 'http://api.crawlbase.com/storage/bulk?token=test')
+        .with(body: { rids: %w[1 2 3] }.to_json)
+        .to_return(
+          status: 200,
+          body: [
+            {
+              'stored_at' => '2021-03-01T14:22:58+02:00',
+              'original_status' => 200,
+              'cb_status' => 201,
+              'rid' => '1',
+              'url' => 'https://www.apple.com'
+            },
+            {
+              'stored_at' => '2021-03-02T14:22:58+02:00',
+              'original_status' => 200,
+              'pc_status' => 202,
+              'rid' => '2',
+              'url' => 'https://www.google.com'
+            },
+            {
+              'stored_at' => '2021-03-03T14:22:58+02:00',
+              'original_status' => 200,
+              'cb_status' => 203,
+              'pc_status' => 500,
+              'rid' => '3',
+              'url' => 'https://www.espn.com'
+            }
+          ].to_json
+        )
+
+      subject.bulk(%w[1 2 3])
+      expect(subject.cb_status).to eq([201, 202, 203])
+      expect(subject.pc_status).to eq([201, 202, 203])
     end
   end
 


### PR DESCRIPTION
## Summary

- Introduce `cb_status` as the preferred public attribute for Crawlbase status on `Crawlbase::API` (and subclasses) and `Crawlbase::StorageAPI`.
- Resolve status from response headers or JSON by preferring `cb_status`, then falling back to legacy `pc_status`.
- Soft-deprecate `pc_status`: keep it supported with the same resolved value and a one-time deprecation warning; do not remove it in this release.
- Document the change in `README.md` and `CHANGELOG.md`, including a migration note from `pc_status` to `cb_status`.
- Bump version to **1.2.0** (minor): additive API with backward-compatible deprecation.

## Motivation

The Crawlbase API is moving toward `cb_status` as the canonical status field/header. Existing library users may still depend on `pc_status`, so this change adopts the new name while preserving compatibility during a deprecation window.

## Behavior

| Response contains | Resolved value |
|---|---|
| Only `cb_status` | That value |
| Only `pc_status` | That value (legacy fallback) |
| Both | `cb_status` (priority) |
| Neither | `0` (existing `.to_i` semantics) |

`response.cb_status` and `response.pc_status` return the same resolved value during the deprecation period.

## Migration

```ruby
# Before (deprecated)
response.pc_status

# After (preferred)
response.cb_status
```

## Test plan

- [x] `bundle exec rspec` passes locally
- [x] Only `cb_status` present → both readers return that value
- [x] Only `pc_status` present → both readers return that value
- [x] Both present with different values → `cb_status` wins; both readers return that value
- [x] Neither present → both return `0`
- [x] JSON body key resolution works for Crawling API (`format: 'json'`) and Storage API
- [x] Storage `#bulk` applies per-item priority
- [x] Calling `pc_status` emits a deprecation warning once per process
- [x] Existing Screenshots / legacy `pc_status` stubs still pass
- [x] README and CHANGELOG accurately describe preferred vs deprecated names
